### PR TITLE
Instance 1: post-pipeline alerting — Telegram + Discord (#10)

### DIFF
--- a/packages/agent/src/config.ts
+++ b/packages/agent/src/config.ts
@@ -90,6 +90,33 @@ export const env = cleanEnv(process.env, {
     desc: 'Path to JSON file with Helius programs to track (overrides built-in list)',
   }),
 
+  // Alerting
+  ALERTS_ENABLED: bool({
+    default: false,
+    desc: 'Enable post-pipeline alert notifications',
+  }),
+  ALERT_CHANNEL: str({
+    choices: ['telegram', 'discord'] as const,
+    default: 'telegram',
+    desc: 'Notification channel for alerts',
+  }),
+  TELEGRAM_BOT_TOKEN: str({
+    default: '',
+    desc: 'Telegram bot token from @BotFather',
+  }),
+  TELEGRAM_CHAT_ID: str({
+    default: '',
+    desc: 'Telegram chat/channel ID for alerts',
+  }),
+  DISCORD_WEBHOOK_URL: str({
+    default: '',
+    desc: 'Discord webhook URL for alerts',
+  }),
+  ALERT_ANOMALY_THRESHOLD: num({
+    default: 3.0,
+    desc: 'Z-score threshold to trigger anomaly spike alerts',
+  }),
+
   // Output — resolve to monorepo root (packages/agent/ → ../../reports)
   REPORTS_DIR: str({
     default: resolve(import.meta.dirname, '..', '..', '..', 'reports'),

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -217,10 +217,14 @@ async function main() {
 
     const { writeJsonReport } = await import('./output/json.js');
     const { writeMarkdownReport } = await import('./output/markdown.js');
+    const { sendReportAlerts } = await import('./output/alerts.js');
 
     const date = now.toISOString().split('T')[0];
     await writeJsonReport(report, date);
     await writeMarkdownReport(report, date);
+
+    // === Phase 6: Send alerts ===
+    await sendReportAlerts(report);
 
     const duration = Date.now() - startTime;
     const failedSources = Object.entries(sourceResults)
@@ -237,6 +241,8 @@ async function main() {
     }, 'SOLIS pipeline complete');
   } catch (error) {
     logger.error({ err: error instanceof Error ? { message: error.message, stack: error.stack, cause: error.cause } : error }, 'Pipeline failed');
+    const { sendFailureAlert } = await import('./output/alerts.js');
+    await sendFailureAlert(error instanceof Error ? error.message : String(error));
     process.exit(1);
   }
 }

--- a/packages/agent/src/output/alerts.ts
+++ b/packages/agent/src/output/alerts.ts
@@ -1,0 +1,258 @@
+import { env } from '../config.js';
+import { logger } from '../logger.js';
+import type { FortnightlyReport } from '@solis/shared';
+
+interface Alert {
+  severity: 'high' | 'medium' | 'low';
+  emoji: string;
+  message: string;
+}
+
+/**
+ * Detect alert-worthy events from the report and diff.
+ */
+export function detectAlerts(report: FortnightlyReport): Alert[] {
+  const alerts: Alert[] = [];
+  const diff = report.diff;
+
+  if (diff) {
+    // Stage transitions (up = high severity)
+    for (const t of diff.stageTransitions) {
+      alerts.push({
+        severity: 'high',
+        emoji: '📈',
+        message: `${t.name}: ${t.from} → ${t.to}`,
+      });
+    }
+
+    // New narratives
+    for (const name of diff.newNarratives) {
+      const narrative = report.narratives.find(n => n.name === name);
+      const detail = narrative ? ` (${narrative.stage}, ${narrative.confidence}%)` : '';
+      alerts.push({
+        severity: 'medium',
+        emoji: '🆕',
+        message: `${name}${detail}`,
+      });
+    }
+
+    // Removed narratives
+    for (const name of diff.removedNarratives) {
+      alerts.push({
+        severity: 'low',
+        emoji: '👻',
+        message: `${name} — no longer detected`,
+      });
+    }
+  }
+
+  // Anomaly spikes (z-score above alert threshold)
+  const threshold = env.ALERT_ANOMALY_THRESHOLD;
+
+  for (const repo of report.signals.leading.anomalies) {
+    if (Math.abs(repo.starsZScore) >= threshold) {
+      alerts.push({
+        severity: 'medium',
+        emoji: '⚡',
+        message: `${repo.repo} stars z-score: ${repo.starsZScore.toFixed(2)}`,
+      });
+    }
+    if (Math.abs(repo.commitsZScore) >= threshold) {
+      alerts.push({
+        severity: 'medium',
+        emoji: '⚡',
+        message: `${repo.repo} commits z-score: ${repo.commitsZScore.toFixed(2)}`,
+      });
+    }
+  }
+
+  for (const signal of report.signals.coincident.onchain) {
+    if (Math.abs(signal.txZScore) >= threshold) {
+      alerts.push({
+        severity: 'medium',
+        emoji: '⚡',
+        message: `${signal.programName} tx z-score: ${signal.txZScore.toFixed(2)}`,
+      });
+    }
+  }
+
+  for (const token of report.signals.confirming.tokens) {
+    if (Math.abs(token.volumeZScore) >= threshold) {
+      alerts.push({
+        severity: 'medium',
+        emoji: '⚡',
+        message: `$${token.symbol} volume z-score: ${token.volumeZScore.toFixed(2)}`,
+      });
+    }
+  }
+
+  return alerts;
+}
+
+/**
+ * Format alerts into a human-readable message.
+ */
+function formatAlertMessage(report: FortnightlyReport, alerts: Alert[]): string {
+  const date = new Date(report.generatedAt).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+
+  const lines = [`🚨 SOLIS Report — ${date}`, ''];
+
+  const transitions = alerts.filter(a => a.emoji === '📈');
+  const newNarratives = alerts.filter(a => a.emoji === '🆕');
+  const anomalies = alerts.filter(a => a.emoji === '⚡');
+  const removed = alerts.filter(a => a.emoji === '👻');
+
+  if (transitions.length > 0) {
+    lines.push('📈 Stage Transitions:');
+    for (const a of transitions) lines.push(`  • ${a.message}`);
+    lines.push('');
+  }
+
+  if (newNarratives.length > 0) {
+    lines.push('🆕 New Narratives:');
+    for (const a of newNarratives) lines.push(`  • ${a.message}`);
+    lines.push('');
+  }
+
+  if (anomalies.length > 0) {
+    lines.push(`⚡ Anomaly Spikes (z > ${env.ALERT_ANOMALY_THRESHOLD}):`);
+    for (const a of anomalies.slice(0, 10)) lines.push(`  • ${a.message}`);
+    if (anomalies.length > 10) lines.push(`  ... and ${anomalies.length - 10} more`);
+    lines.push('');
+  }
+
+  if (removed.length > 0) {
+    lines.push('👻 Faded Signals:');
+    for (const a of removed) lines.push(`  • ${a.message}`);
+    lines.push('');
+  }
+
+  lines.push(`📊 ${report.meta.narrativesIdentified} narratives | ${report.meta.anomaliesDetected} anomalies | $${report.meta.llmCostUsd.toFixed(2)} LLM cost`);
+  lines.push(`🔗 https://solis.rectorspace.com`);
+
+  return lines.join('\n');
+}
+
+/**
+ * Format a pipeline failure alert.
+ */
+export function formatFailureMessage(error: string): string {
+  return [
+    '🔴 SOLIS Pipeline Failed',
+    '',
+    `Error: ${error}`,
+    '',
+    'Check workflow logs for details.',
+  ].join('\n');
+}
+
+/**
+ * Send a message via Telegram Bot API.
+ */
+async function sendTelegram(text: string): Promise<void> {
+  const { TELEGRAM_BOT_TOKEN, TELEGRAM_CHAT_ID } = env;
+  if (!TELEGRAM_BOT_TOKEN || !TELEGRAM_CHAT_ID) {
+    throw new Error('TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID are required');
+  }
+
+  const url = `https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      chat_id: TELEGRAM_CHAT_ID,
+      text,
+      parse_mode: 'HTML',
+      disable_web_page_preview: true,
+    }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Telegram API error ${res.status}: ${body}`);
+  }
+}
+
+/**
+ * Send a message via Discord webhook.
+ */
+async function sendDiscord(text: string): Promise<void> {
+  const { DISCORD_WEBHOOK_URL } = env;
+  if (!DISCORD_WEBHOOK_URL) {
+    throw new Error('DISCORD_WEBHOOK_URL is required');
+  }
+
+  const res = await fetch(DISCORD_WEBHOOK_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ content: text }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Discord webhook error ${res.status}: ${body}`);
+  }
+}
+
+/**
+ * Send a message through the configured alert channel.
+ */
+async function send(text: string): Promise<void> {
+  switch (env.ALERT_CHANNEL) {
+    case 'telegram':
+      return sendTelegram(text);
+    case 'discord':
+      return sendDiscord(text);
+    default:
+      throw new Error(`Unknown alert channel: ${env.ALERT_CHANNEL}`);
+  }
+}
+
+/**
+ * Send post-pipeline alerts for significant events.
+ * Gracefully handles failures — alert errors never crash the pipeline.
+ */
+export async function sendReportAlerts(report: FortnightlyReport): Promise<void> {
+  if (!env.ALERTS_ENABLED) return;
+
+  const log = logger.child({ component: 'alerts' });
+
+  try {
+    const alerts = detectAlerts(report);
+
+    if (alerts.length === 0) {
+      log.info('No alert-worthy events detected');
+      return;
+    }
+
+    const message = formatAlertMessage(report, alerts);
+    log.info({ alertCount: alerts.length, channel: env.ALERT_CHANNEL }, 'Sending alerts');
+
+    await send(message);
+    log.info({ alertCount: alerts.length }, 'Alerts sent successfully');
+  } catch (err) {
+    log.error({ error: err instanceof Error ? err.message : err }, 'Failed to send alerts — pipeline continues');
+  }
+}
+
+/**
+ * Send a pipeline failure alert.
+ * Gracefully handles failures — double fault won't crash.
+ */
+export async function sendFailureAlert(error: string): Promise<void> {
+  if (!env.ALERTS_ENABLED) return;
+
+  const log = logger.child({ component: 'alerts' });
+
+  try {
+    const message = formatFailureMessage(error);
+    await send(message);
+    log.info('Failure alert sent');
+  } catch (err) {
+    log.error({ error: err instanceof Error ? err.message : err }, 'Failed to send failure alert');
+  }
+}

--- a/packages/agent/tests/output/alerts.test.ts
+++ b/packages/agent/tests/output/alerts.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../src/config.js', () => ({
+  env: {
+    ALERTS_ENABLED: true,
+    ALERT_CHANNEL: 'telegram',
+    TELEGRAM_BOT_TOKEN: 'test-token',
+    TELEGRAM_CHAT_ID: '123456',
+    DISCORD_WEBHOOK_URL: '',
+    ALERT_ANOMALY_THRESHOLD: 3.0,
+    LOG_LEVEL: 'error',
+  },
+}));
+
+vi.mock('../../src/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  },
+}));
+
+import { detectAlerts, formatFailureMessage } from '../../src/output/alerts.js';
+import type { FortnightlyReport, Narrative } from '@solis/shared';
+
+function makeNarrative(overrides: Partial<Narrative> = {}): Narrative {
+  return {
+    id: 'n-1',
+    name: 'Test Narrative',
+    slug: 'test-narrative',
+    description: 'A test',
+    stage: 'EMERGING',
+    momentum: 'stable',
+    confidence: 75,
+    signals: { leading: [], coincident: [], confirming: [] },
+    relatedRepos: [],
+    relatedTokens: [],
+    relatedProtocols: [],
+    ...overrides,
+  };
+}
+
+function makeReport(overrides: Partial<FortnightlyReport> = {}): FortnightlyReport {
+  return {
+    version: '1.0',
+    generatedAt: '2026-02-12T08:00:00Z',
+    period: { start: '2026-01-29T08:00:00Z', end: '2026-02-12T08:00:00Z' },
+    sources: [],
+    signals: {
+      leading: { period: { start: '', end: '' }, repos: [], anomalies: [], newRepoClusters: [] },
+      coincident: {
+        period: { start: '', end: '' },
+        tvl: { total: 0, totalDelta: 0, protocols: [], anomalies: [] },
+        dexVolumes: { total: 0, protocols: [] },
+        stablecoinFlows: { netFlow: 0, inflows: 0, outflows: 0 },
+        onchain: [],
+      },
+      confirming: { period: { start: '', end: '' }, tokens: [], trending: [], categoryPerformance: [] },
+    },
+    narratives: [makeNarrative()],
+    buildIdeas: [],
+    meta: {
+      totalReposAnalyzed: 50,
+      totalProtocolsAnalyzed: 20,
+      totalTokensAnalyzed: 30,
+      anomaliesDetected: 5,
+      narrativesIdentified: 1,
+      buildIdeasGenerated: 0,
+      llmModel: 'test',
+      llmTokensUsed: 1000,
+      llmCostUsd: 0.01,
+      pipelineDurationMs: 5000,
+    },
+    ...overrides,
+  };
+}
+
+describe('detectAlerts', () => {
+  it('returns empty alerts when no diff and no anomalies', () => {
+    const report = makeReport();
+    const alerts = detectAlerts(report);
+    expect(alerts).toEqual([]);
+  });
+
+  it('detects stage transitions as high severity', () => {
+    const report = makeReport({
+      diff: {
+        newNarratives: [],
+        removedNarratives: [],
+        stageTransitions: [{ name: 'DePIN', from: 'EARLY', to: 'EMERGING' }],
+        confidenceChanges: [],
+      },
+    });
+
+    const alerts = detectAlerts(report);
+
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].severity).toBe('high');
+    expect(alerts[0].message).toContain('DePIN');
+    expect(alerts[0].message).toContain('EARLY → EMERGING');
+  });
+
+  it('detects new narratives as medium severity', () => {
+    const report = makeReport({
+      narratives: [makeNarrative({ name: 'New Thing', stage: 'EARLY', confidence: 80 })],
+      diff: {
+        newNarratives: ['New Thing'],
+        removedNarratives: [],
+        stageTransitions: [],
+        confidenceChanges: [],
+      },
+    });
+
+    const alerts = detectAlerts(report);
+
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].severity).toBe('medium');
+    expect(alerts[0].message).toContain('New Thing');
+    expect(alerts[0].message).toContain('EARLY');
+  });
+
+  it('detects removed narratives as low severity', () => {
+    const report = makeReport({
+      diff: {
+        newNarratives: [],
+        removedNarratives: ['Old Thing'],
+        stageTransitions: [],
+        confidenceChanges: [],
+      },
+    });
+
+    const alerts = detectAlerts(report);
+
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].severity).toBe('low');
+    expect(alerts[0].message).toContain('Old Thing');
+  });
+
+  it('detects anomaly spikes above threshold', () => {
+    const report = makeReport({
+      signals: {
+        leading: {
+          period: { start: '', end: '' },
+          repos: [],
+          anomalies: [{
+            repo: 'test/repo',
+            stars: 100, starsDelta: 50, starsZScore: 3.5,
+            commits: 200, commitsDelta: 100, commitsZScore: 1.0,
+            forks: 10, forksDelta: 5, forksZScore: 0.5,
+            contributors: 5, contributorsDelta: 2,
+            newRepo: false, language: 'TypeScript', topics: [],
+          }],
+          newRepoClusters: [],
+        },
+        coincident: {
+          period: { start: '', end: '' },
+          tvl: { total: 0, totalDelta: 0, protocols: [], anomalies: [] },
+          dexVolumes: { total: 0, protocols: [] },
+          stablecoinFlows: { netFlow: 0, inflows: 0, outflows: 0 },
+          onchain: [],
+        },
+        confirming: { period: { start: '', end: '' }, tokens: [], trending: [], categoryPerformance: [] },
+      },
+    });
+
+    const alerts = detectAlerts(report);
+
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0].message).toContain('test/repo');
+    expect(alerts[0].message).toContain('3.50');
+  });
+
+  it('ignores anomalies below threshold', () => {
+    const report = makeReport({
+      signals: {
+        leading: {
+          period: { start: '', end: '' },
+          repos: [],
+          anomalies: [{
+            repo: 'test/repo',
+            stars: 100, starsDelta: 50, starsZScore: 2.5,
+            commits: 200, commitsDelta: 100, commitsZScore: 2.0,
+            forks: 10, forksDelta: 5, forksZScore: 0.5,
+            contributors: 5, contributorsDelta: 2,
+            newRepo: false, language: 'TypeScript', topics: [],
+          }],
+          newRepoClusters: [],
+        },
+        coincident: {
+          period: { start: '', end: '' },
+          tvl: { total: 0, totalDelta: 0, protocols: [], anomalies: [] },
+          dexVolumes: { total: 0, protocols: [] },
+          stablecoinFlows: { netFlow: 0, inflows: 0, outflows: 0 },
+          onchain: [],
+        },
+        confirming: { period: { start: '', end: '' }, tokens: [], trending: [], categoryPerformance: [] },
+      },
+    });
+
+    const alerts = detectAlerts(report);
+    expect(alerts).toEqual([]);
+  });
+});
+
+describe('formatFailureMessage', () => {
+  it('formats a failure message', () => {
+    const message = formatFailureMessage('Connection timeout');
+    expect(message).toContain('Pipeline Failed');
+    expect(message).toContain('Connection timeout');
+  });
+});


### PR DESCRIPTION
## Summary

Adds a post-pipeline alerting system that fires notifications on significant events. Supports Telegram (recommended) and Discord webhook channels. Alert errors are gracefully caught — they never crash the pipeline.

## Alert triggers

| Trigger | Condition | Severity |
|---------|-----------|----------|
| Stage transition | Narrative moved up (EARLY→EMERGING, etc.) | High |
| New narrative | Not in previous report | Medium |
| Anomaly spike | Any metric z-score > `ALERT_ANOMALY_THRESHOLD` (default 3.0) | Medium |
| Narrative disappeared | Was in previous report, gone now | Low |
| Pipeline failure | Agent exits non-zero | High |

## New env vars

| Var | Default | Purpose |
|-----|---------|---------|
| `ALERTS_ENABLED` | false | Enable alerting |
| `ALERT_CHANNEL` | telegram | `telegram` or `discord` |
| `TELEGRAM_BOT_TOKEN` | (empty) | Bot token from @BotFather |
| `TELEGRAM_CHAT_ID` | (empty) | Chat/channel ID |
| `DISCORD_WEBHOOK_URL` | (empty) | Discord webhook URL |
| `ALERT_ANOMALY_THRESHOLD` | 3.0 | Z-score threshold for spike alerts |

## New files

- `packages/agent/src/output/alerts.ts` — detection, formatting, Telegram/Discord senders
- `packages/agent/tests/output/alerts.test.ts` — 7 tests for alert detection logic

## Test plan

- [x] `pnpm typecheck` — zero errors
- [x] `pnpm test:run` — 138/138 passing (7 new alert tests)
- [ ] Set `ALERTS_ENABLED=true` + Telegram creds, run `pnpm agent`, verify message arrives
- [ ] Test failure alert: set an invalid `OPENROUTER_API_KEY`, verify failure notification

---
Created via `/git:solve 1`