### PR TITLE
fix: code audit hardening — security, reliability, and test coverage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,115 @@
+# =============================================================================
+# SOLIS — Environment Configuration
+# Copy to .env and fill in required values
+# =============================================================================
+
+# --- Required (Agent) --------------------------------------------------------
+
+# OpenRouter API key for LLM analysis (narrative clustering + idea generation)
+OPENROUTER_API_KEY=
+
+# GitHub personal access token (5K req/hr)
+GITHUB_TOKEN=
+
+# Helius API key for onchain data (1M credits/mo free)
+HELIUS_API_KEY=
+
+# --- Optional (Agent) --------------------------------------------------------
+
+# CoinGecko Pro API key (optional, increases rate limit)
+COINGECKO_API_KEY=
+
+# LLM model and fallbacks
+OPENROUTER_MODEL=anthropic/claude-haiku-4.5
+OPENROUTER_FALLBACK_MODELS=z-ai/glm-4.7,z-ai/glm-4.7-flash
+
+# Collection and analysis
+COLLECTION_PERIOD_DAYS=14
+ANOMALY_THRESHOLD=2.0
+
+# LLM signal condensation limits
+LLM_TOP_REPOS=30
+LLM_TOP_PROGRAMS=15
+LLM_TOP_TOKENS=20
+
+# API throttle delays (ms)
+GITHUB_THROTTLE_MS=500
+COINGECKO_THROTTLE_MS=2000
+HELIUS_THROTTLE_MS=300
+
+# Data filters
+COINGECKO_MAX_PAGES=2
+DEFILLAMA_MIN_TVL=100000
+
+# Custom Helius programs list (JSON file path, overrides built-in)
+HELIUS_PROGRAMS_PATH=
+
+# Signal caching
+CACHE_ENABLED=true
+CACHE_TTL_HOURS=20
+
+# Reports output directory
+REPORTS_DIR=
+
+# Logging
+LOG_LEVEL=info
+
+# --- Layer 0: Social Signals (opt-in) ----------------------------------------
+
+# LunarCrush
+ENABLE_SOCIAL_SIGNALS=false
+LUNARCRUSH_API_KEY=
+LUNARCRUSH_THROTTLE_MS=1000
+LLM_TOP_SOCIAL_COINS=20
+
+# X/Twitter
+ENABLE_X_SIGNALS=false
+X_BEARER_TOKEN=
+X_THROTTLE_MS=1000
+X_KOL_HANDLES=mert,toly,akshaybd,MessariCrypto,a16zcrypto,solana_devs
+X_TWEETS_PER_KOL=5
+LLM_TOP_X_TOPICS=20
+
+# --- Repo Discovery (opt-in) -------------------------------------------------
+
+ENABLE_REPO_DISCOVERY=false
+DISCOVERY_MIN_STARS=50
+
+# --- Alerting -----------------------------------------------------------------
+
+ALERTS_ENABLED=false
+ALERT_CHANNEL=telegram
+ALERT_ANOMALY_THRESHOLD=3.0
+TELEGRAM_BOT_TOKEN=
+TELEGRAM_CHAT_ID=
+DISCORD_WEBHOOK_URL=
+
+# --- Heartbeat Daemon ---------------------------------------------------------
+
+HEARTBEAT_HOUR=8
+GIT_PUSH_ENABLED=true
+HEARTBEAT_LOCK_PATH=/tmp/solis-heartbeat.lock
+
+# --- Web ----------------------------------------------------------------------
+
+# API rate limiting
+API_RATE_LIMIT=30
+API_RATE_WINDOW_MS=3600000
+
+# x402 micropayments (opt-in)
+ENABLE_X402=false
+X402_RECEIVER_ADDRESS=
+X402_PRICE_CENTS=1
+X402_FACILITATOR_URL=https://x402.org/facilitator
+
+# Custom query API
+QUERY_API_MODEL=anthropic/claude-haiku-4-5-20251001
+
+# Email digest
+RESEND_API_KEY=
+DIGEST_FROM_EMAIL=digest@solis.rectorspace.com
+DIGEST_UNSUBSCRIBE_SECRET=
+DIGEST_API_SECRET=
+
+# Data directory (subscriber storage)
+DATA_DIR=

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Deploy to VPS
         uses: appleboy/ssh-action@v1.0.0
         with:
-          host: 176.222.53.185
+          host: ${{ secrets.VPS_HOST }}
           username: solis
           key: ${{ secrets.VPS_SSH_KEY }}
           script: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,14 @@ services:
     volumes:
       - /home/solis/solis/reports:/app/reports:ro
       - /home/solis/solis/data:/app/data:rw
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+          cpus: '1.5'
+        reservations:
+          memory: 256M
+          cpus: '0.5'
     healthcheck:
       test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:3001/"]
       interval: 30s

--- a/packages/agent/src/heartbeat-utils.ts
+++ b/packages/agent/src/heartbeat-utils.ts
@@ -1,0 +1,104 @@
+import {
+  openSync,
+  closeSync,
+  writeFileSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  constants,
+} from 'node:fs';
+import { logger } from './logger.js';
+
+// --- State ---
+
+export interface SolisState {
+  lastRunTime: number;
+  lastRunDate: string;
+  consecutiveFailures: number;
+  cycleCount: number;
+  totalReports: number;
+}
+
+export const DEFAULT_STATE: SolisState = {
+  lastRunTime: 0,
+  lastRunDate: '',
+  consecutiveFailures: 0,
+  cycleCount: 0,
+  totalReports: 0,
+};
+
+export function loadState(stateFile: string): SolisState {
+  try {
+    const raw = readFileSync(stateFile, 'utf-8');
+    return { ...DEFAULT_STATE, ...JSON.parse(raw) };
+  } catch {
+    return { ...DEFAULT_STATE };
+  }
+}
+
+export function saveState(state: SolisState, stateFile: string): void {
+  const tempFile = `${stateFile}.tmp.${process.pid}`;
+  try {
+    writeFileSync(tempFile, JSON.stringify(state, null, 2));
+    renameSync(tempFile, stateFile);
+  } catch (err) {
+    try { unlinkSync(tempFile); } catch { /* ignore */ }
+    throw err;
+  }
+}
+
+// --- Lock file ---
+
+export function acquireLock(lockFile: string): boolean {
+  try {
+    const fd = openSync(lockFile, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY);
+    writeFileSync(fd, String(process.pid));
+    closeSync(fd);
+    return true;
+  } catch (err: any) {
+    if (err.code !== 'EEXIST') throw err;
+
+    // Check for stale lock
+    try {
+      const pid = parseInt(readFileSync(lockFile, 'utf-8').trim(), 10);
+      process.kill(pid, 0); // Throws if process doesn't exist
+      return false; // Process alive — genuine lock
+    } catch {
+      // Stale lock — remove and retry
+      logger.warn('Removing stale lock file');
+      try { unlinkSync(lockFile); } catch { /* ignore */ }
+      try {
+        const fd = openSync(lockFile, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY);
+        writeFileSync(fd, String(process.pid));
+        closeSync(fd);
+        return true;
+      } catch {
+        return false;
+      }
+    }
+  }
+}
+
+export function releaseLock(lockFile: string): void {
+  try { unlinkSync(lockFile); } catch { /* ignore */ }
+}
+
+// --- Scheduling ---
+
+export function msUntilNextRun(heartbeatHour: number): number {
+  const now = new Date();
+  const target = new Date(now);
+  target.setUTCHours(heartbeatHour, 0, 0, 0);
+
+  if (now.getTime() >= target.getTime()) {
+    target.setUTCDate(target.getUTCDate() + 1);
+  }
+
+  return target.getTime() - now.getTime();
+}
+
+export function formatDuration(ms: number): string {
+  const h = Math.floor(ms / 3_600_000);
+  const m = Math.floor((ms % 3_600_000) / 60_000);
+  return `${h}h ${m}m`;
+}

--- a/packages/agent/src/heartbeat.ts
+++ b/packages/agent/src/heartbeat.ts
@@ -1,16 +1,15 @@
 import 'dotenv/config';
-import {
-  openSync,
-  closeSync,
-  writeFileSync,
-  readFileSync,
-  renameSync,
-  unlinkSync,
-  constants,
-} from 'node:fs';
 import { execSync } from 'node:child_process';
 import { logger } from './logger.js';
 import { runPipeline } from './index.js';
+import {
+  loadState,
+  saveState,
+  acquireLock,
+  releaseLock,
+  msUntilNextRun,
+  formatDuration,
+} from './heartbeat-utils.js';
 
 // --- Configuration ---
 
@@ -18,100 +17,6 @@ const LOCK_FILE = process.env.HEARTBEAT_LOCK_PATH || '/tmp/solis-heartbeat.lock'
 const STATE_FILE = '.solis-state.json';
 const HEARTBEAT_HOUR = parseInt(process.env.HEARTBEAT_HOUR || '8', 10);
 const GIT_PUSH_ENABLED = process.env.GIT_PUSH_ENABLED !== 'false';
-
-// --- State ---
-
-interface SolisState {
-  lastRunTime: number;
-  lastRunDate: string;
-  consecutiveFailures: number;
-  cycleCount: number;
-  totalReports: number;
-}
-
-const DEFAULT_STATE: SolisState = {
-  lastRunTime: 0,
-  lastRunDate: '',
-  consecutiveFailures: 0,
-  cycleCount: 0,
-  totalReports: 0,
-};
-
-function loadState(): SolisState {
-  try {
-    const raw = readFileSync(STATE_FILE, 'utf-8');
-    return { ...DEFAULT_STATE, ...JSON.parse(raw) };
-  } catch {
-    return { ...DEFAULT_STATE };
-  }
-}
-
-function saveState(state: SolisState): void {
-  const tempFile = `${STATE_FILE}.tmp.${process.pid}`;
-  try {
-    writeFileSync(tempFile, JSON.stringify(state, null, 2));
-    renameSync(tempFile, STATE_FILE);
-  } catch (err) {
-    try { unlinkSync(tempFile); } catch { /* ignore */ }
-    throw err;
-  }
-}
-
-// --- Lock file ---
-
-function acquireLock(): boolean {
-  try {
-    const fd = openSync(LOCK_FILE, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY);
-    writeFileSync(fd, String(process.pid));
-    closeSync(fd);
-    return true;
-  } catch (err: any) {
-    if (err.code !== 'EEXIST') throw err;
-
-    // Check for stale lock
-    try {
-      const pid = parseInt(readFileSync(LOCK_FILE, 'utf-8').trim(), 10);
-      process.kill(pid, 0); // Throws if process doesn't exist
-      return false; // Process alive — genuine lock
-    } catch {
-      // Stale lock — remove and retry
-      logger.warn('Removing stale lock file');
-      try { unlinkSync(LOCK_FILE); } catch { /* ignore */ }
-      try {
-        const fd = openSync(LOCK_FILE, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY);
-        writeFileSync(fd, String(process.pid));
-        closeSync(fd);
-        return true;
-      } catch {
-        return false;
-      }
-    }
-  }
-}
-
-function releaseLock(): void {
-  try { unlinkSync(LOCK_FILE); } catch { /* ignore */ }
-}
-
-// --- Scheduling ---
-
-function msUntilNextRun(): number {
-  const now = new Date();
-  const target = new Date(now);
-  target.setUTCHours(HEARTBEAT_HOUR, 0, 0, 0);
-
-  if (now.getTime() >= target.getTime()) {
-    target.setUTCDate(target.getUTCDate() + 1);
-  }
-
-  return target.getTime() - now.getTime();
-}
-
-function formatDuration(ms: number): string {
-  const h = Math.floor(ms / 3_600_000);
-  const m = Math.floor((ms % 3_600_000) / 60_000);
-  return `${h}h ${m}m`;
-}
 
 function formatUptime(startTime: number): string {
   return formatDuration(Date.now() - startTime);
@@ -153,13 +58,13 @@ function sleep(ms: number, signal: AbortSignal): Promise<void> {
 // --- Main heartbeat loop ---
 
 async function heartbeat(): Promise<void> {
-  if (!acquireLock()) {
+  if (!acquireLock(LOCK_FILE)) {
     logger.error('Another instance is running. Exiting to prevent duplicate runs.');
     process.exit(1);
   }
 
   const daemonStart = Date.now();
-  const state = loadState();
+  const state = loadState(STATE_FILE);
   let stopping = false;
   const ac = new AbortController();
 
@@ -167,7 +72,7 @@ async function heartbeat(): Promise<void> {
     if (stopping) return;
     stopping = true;
     ac.abort();
-    releaseLock();
+    releaseLock(LOCK_FILE);
     logger.info({
       cycleCount: state.cycleCount,
       totalReports: state.totalReports,
@@ -178,7 +83,7 @@ async function heartbeat(): Promise<void> {
 
   process.on('SIGINT', shutdown);
   process.on('SIGTERM', shutdown);
-  process.on('exit', releaseLock);
+  process.on('exit', () => releaseLock(LOCK_FILE));
 
   logger.info({
     targetHourUTC: HEARTBEAT_HOUR,
@@ -189,7 +94,7 @@ async function heartbeat(): Promise<void> {
   }, 'SOLIS heartbeat daemon started');
 
   while (!stopping) {
-    const sleepMs = msUntilNextRun();
+    const sleepMs = msUntilNextRun(HEARTBEAT_HOUR);
     logger.info({ nextRunIn: formatDuration(sleepMs) }, `Sleeping until ${HEARTBEAT_HOUR}:00 UTC`);
 
     await sleep(sleepMs, ac.signal);
@@ -214,7 +119,7 @@ async function heartbeat(): Promise<void> {
       state.lastRunDate = today;
       state.consecutiveFailures = 0;
       state.totalReports++;
-      saveState(state);
+      saveState(state, STATE_FILE);
 
       logger.info({
         date: today,
@@ -223,7 +128,7 @@ async function heartbeat(): Promise<void> {
       }, 'Pipeline cycle complete');
     } catch (err) {
       state.consecutiveFailures++;
-      saveState(state);
+      saveState(state, STATE_FILE);
 
       logger.error({
         consecutiveFailures: state.consecutiveFailures,
@@ -238,7 +143,7 @@ async function heartbeat(): Promise<void> {
     }
 
     state.cycleCount++;
-    saveState(state);
+    saveState(state, STATE_FILE);
   }
 }
 

--- a/packages/agent/src/heartbeat.ts
+++ b/packages/agent/src/heartbeat.ts
@@ -14,7 +14,7 @@ import { runPipeline } from './index.js';
 
 // --- Configuration ---
 
-const LOCK_FILE = '/tmp/solis-heartbeat.lock';
+const LOCK_FILE = process.env.HEARTBEAT_LOCK_PATH || '/tmp/solis-heartbeat.lock';
 const STATE_FILE = '.solis-state.json';
 const HEARTBEAT_HOUR = parseInt(process.env.HEARTBEAT_HOUR || '8', 10);
 const GIT_PUSH_ENABLED = process.env.GIT_PUSH_ENABLED !== 'false';

--- a/packages/agent/src/output/alerts.ts
+++ b/packages/agent/src/output/alerts.ts
@@ -1,3 +1,4 @@
+import { fetchWithTimeout } from '@solis/shared/fetch';
 import { env } from '../config.js';
 import { logger } from '../logger.js';
 import type { FortnightlyReport } from '@solis/shared';
@@ -160,7 +161,7 @@ async function sendTelegram(text: string): Promise<void> {
   }
 
   const url = `https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage`;
-  const res = await fetch(url, {
+  const res = await fetchWithTimeout(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -186,7 +187,7 @@ async function sendDiscord(text: string): Promise<void> {
     throw new Error('DISCORD_WEBHOOK_URL is required');
   }
 
-  const res = await fetch(DISCORD_WEBHOOK_URL, {
+  const res = await fetchWithTimeout(DISCORD_WEBHOOK_URL, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ content: text }),

--- a/packages/agent/src/tools/coingecko.ts
+++ b/packages/agent/src/tools/coingecko.ts
@@ -1,3 +1,4 @@
+import { fetchWithTimeout } from '@solis/shared/fetch';
 import { env } from '../config.js';
 import { logger } from '../logger.js';
 import type { CacheStore } from '../cache/index.js';
@@ -23,13 +24,13 @@ async function cgFetch<T>(path: string, params: Record<string, string> = {}): Pr
 
   const start = Date.now();
   try {
-    const res = await fetch(url.toString(), { headers });
+    const res = await fetchWithTimeout(url.toString(), { headers });
 
     if (res.status === 429) {
       const retryAfter = res.headers.get('retry-after');
       logger.warn({ path, retryAfter, latency: Date.now() - start }, 'CoinGecko rate limited');
       await new Promise(resolve => setTimeout(resolve, (parseInt(retryAfter ?? '5', 10) + 1) * 1000));
-      const retry = await fetch(url.toString(), { headers });
+      const retry = await fetchWithTimeout(url.toString(), { headers });
       if (!retry.ok) return null;
       return (await retry.json()) as T;
     }

--- a/packages/agent/src/tools/defillama.ts
+++ b/packages/agent/src/tools/defillama.ts
@@ -1,3 +1,4 @@
+import { fetchWithTimeout } from '@solis/shared/fetch';
 import { env } from '../config.js';
 import { logger } from '../logger.js';
 import type { CacheStore } from '../cache/index.js';
@@ -8,7 +9,7 @@ const DEFILLAMA_API = 'https://api.llama.fi';
 async function llamaFetch<T>(url: string): Promise<T | null> {
   const start = Date.now();
   try {
-    const res = await fetch(url, {
+    const res = await fetchWithTimeout(url, {
       headers: { Accept: 'application/json' },
     });
 

--- a/packages/agent/src/tools/github.ts
+++ b/packages/agent/src/tools/github.ts
@@ -1,3 +1,4 @@
+import { fetchWithTimeout } from '@solis/shared/fetch';
 import { env } from '../config.js';
 import { logger } from '../logger.js';
 import type { CacheStore } from '../cache/index.js';
@@ -23,7 +24,7 @@ export async function ghFetch<T>(path: string): Promise<T | null> {
   const url = `${GITHUB_API}${path}`;
   const start = Date.now();
   try {
-    const res = await fetch(url, {
+    const res = await fetchWithTimeout(url, {
       headers: {
         Authorization: `Bearer ${env.GITHUB_TOKEN}`,
         Accept: 'application/vnd.github+json',
@@ -54,7 +55,7 @@ async function getCommitActivity(owner: string, name: string): Promise<GitHubApi
 }
 
 async function getContributorCount(owner: string, name: string): Promise<number> {
-  const res = await fetch(`${GITHUB_API}/repos/${owner}/${name}/contributors?per_page=1&anon=true`, {
+  const res = await fetchWithTimeout(`${GITHUB_API}/repos/${owner}/${name}/contributors?per_page=1&anon=true`, {
     headers: {
       Authorization: `Bearer ${env.GITHUB_TOKEN}`,
       Accept: 'application/vnd.github+json',

--- a/packages/agent/src/tools/helius.ts
+++ b/packages/agent/src/tools/helius.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'node:fs';
+import { fetchWithTimeout } from '@solis/shared/fetch';
 import { env } from '../config.js';
 import { logger } from '../logger.js';
 import type { CacheStore } from '../cache/index.js';
@@ -11,7 +12,7 @@ async function heliusRpc<T>(method: string, params: unknown): Promise<T | null> 
   const start = Date.now();
 
   try {
-    const res = await fetch(url, {
+    const res = await fetchWithTimeout(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({

--- a/packages/agent/src/tools/lunarcrush.ts
+++ b/packages/agent/src/tools/lunarcrush.ts
@@ -1,3 +1,4 @@
+import { fetchWithTimeout } from '@solis/shared/fetch';
 import { env } from '../config.js';
 import { logger } from '../logger.js';
 import type { SocialSignal, SocialSignals } from '@solis/shared';
@@ -17,13 +18,13 @@ async function lcFetch<T>(path: string, params: Record<string, string> = {}): Pr
 
   const start = Date.now();
   try {
-    const res = await fetch(url.toString(), { headers });
+    const res = await fetchWithTimeout(url.toString(), { headers });
 
     if (res.status === 429) {
       const retryAfter = res.headers.get('retry-after');
       logger.warn({ path, retryAfter, latency: Date.now() - start }, 'LunarCrush rate limited');
       await new Promise(resolve => setTimeout(resolve, (parseInt(retryAfter ?? '5', 10) + 1) * 1000));
-      const retry = await fetch(url.toString(), { headers });
+      const retry = await fetchWithTimeout(url.toString(), { headers });
       if (!retry.ok) return null;
       return (await retry.json()) as T;
     }

--- a/packages/agent/src/tools/twitter.ts
+++ b/packages/agent/src/tools/twitter.ts
@@ -1,3 +1,4 @@
+import { fetchWithTimeout } from '@solis/shared/fetch';
 import { env } from '../config.js';
 import { logger } from '../logger.js';
 import type { XTopicSignal, XSignals } from '@solis/shared';
@@ -69,7 +70,7 @@ async function xFetch<T>(path: string, params: Record<string, string> = {}): Pro
 
   const start = Date.now();
   try {
-    const res = await fetch(url.toString(), { headers });
+    const res = await fetchWithTimeout(url.toString(), { headers });
 
     if (res.status === 429) {
       const resetHeader = res.headers.get('x-rate-limit-reset');
@@ -78,7 +79,7 @@ async function xFetch<T>(path: string, params: Record<string, string> = {}): Pro
         : 15_000;
       logger.warn({ path, waitMs, latency: Date.now() - start }, 'X API rate limited — retrying');
       await new Promise(resolve => setTimeout(resolve, waitMs));
-      const retry = await fetch(url.toString(), { headers });
+      const retry = await fetchWithTimeout(url.toString(), { headers });
       if (!retry.ok) return null;
       return (await retry.json()) as T;
     }

--- a/packages/agent/tests/heartbeat.test.ts
+++ b/packages/agent/tests/heartbeat.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { join } from 'node:path';
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, openSync, closeSync, constants } from 'node:fs';
+import { tmpdir } from 'node:os';
+
+vi.mock('../src/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  },
+}));
+
+import {
+  loadState,
+  saveState,
+  acquireLock,
+  releaseLock,
+  msUntilNextRun,
+  formatDuration,
+  DEFAULT_STATE,
+} from '../src/heartbeat-utils.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'solis-hb-test-'));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('loadState', () => {
+  it('returns default state when file does not exist', () => {
+    const state = loadState(join(tmpDir, 'nonexistent.json'));
+    expect(state).toEqual(DEFAULT_STATE);
+  });
+
+  it('parses saved state and merges with defaults', () => {
+    const stateFile = join(tmpDir, 'state.json');
+    saveState({ ...DEFAULT_STATE, totalReports: 42, lastRunDate: '2026-02-14' }, stateFile);
+    const state = loadState(stateFile);
+    expect(state.totalReports).toBe(42);
+    expect(state.lastRunDate).toBe('2026-02-14');
+    expect(state.consecutiveFailures).toBe(0);
+  });
+});
+
+describe('saveState', () => {
+  it('writes state to file and can round-trip', () => {
+    const stateFile = join(tmpDir, 'state.json');
+    const state = { ...DEFAULT_STATE, cycleCount: 10, totalReports: 5 };
+    saveState(state, stateFile);
+
+    const raw = readFileSync(stateFile, 'utf-8');
+    const parsed = JSON.parse(raw);
+    expect(parsed.cycleCount).toBe(10);
+    expect(parsed.totalReports).toBe(5);
+
+    const loaded = loadState(stateFile);
+    expect(loaded).toEqual(state);
+  });
+});
+
+describe('acquireLock / releaseLock', () => {
+  it('acquires lock successfully', () => {
+    const lockFile = join(tmpDir, 'test.lock');
+    const result = acquireLock(lockFile);
+    expect(result).toBe(true);
+    expect(existsSync(lockFile)).toBe(true);
+
+    const content = readFileSync(lockFile, 'utf-8');
+    expect(content).toBe(String(process.pid));
+
+    releaseLock(lockFile);
+    expect(existsSync(lockFile)).toBe(false);
+  });
+
+  it('fails when lock exists for current process', () => {
+    const lockFile = join(tmpDir, 'test.lock');
+    acquireLock(lockFile);
+
+    // Second acquire should fail since our own PID is alive
+    const result = acquireLock(lockFile);
+    expect(result).toBe(false);
+
+    releaseLock(lockFile);
+  });
+
+  it('recovers stale lock from dead PID', () => {
+    const lockFile = join(tmpDir, 'test.lock');
+    // Write a lock with a definitely-dead PID
+    const fd = openSync(lockFile, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY);
+    writeFileSync(fd, '999999');
+    closeSync(fd);
+
+    // acquireLock should detect stale and recover
+    const result = acquireLock(lockFile);
+    expect(result).toBe(true);
+
+    releaseLock(lockFile);
+  });
+
+  it('releaseLock is safe to call when no lock exists', () => {
+    const lockFile = join(tmpDir, 'nonexistent.lock');
+    expect(() => releaseLock(lockFile)).not.toThrow();
+  });
+});
+
+describe('msUntilNextRun', () => {
+  it('returns positive value', () => {
+    const ms = msUntilNextRun(8);
+    expect(ms).toBeGreaterThan(0);
+    expect(ms).toBeLessThanOrEqual(24 * 60 * 60 * 1000);
+  });
+
+  it('returns roughly 24h when just past target hour', () => {
+    const now = new Date();
+    const justPastHour = now.getUTCHours();
+    const ms = msUntilNextRun(justPastHour);
+    // Should be close to 24h (minus a few ms for execution time)
+    expect(ms).toBeGreaterThan(23 * 60 * 60 * 1000);
+  });
+});
+
+describe('formatDuration', () => {
+  it('formats hours and minutes', () => {
+    expect(formatDuration(3_600_000)).toBe('1h 0m');
+    expect(formatDuration(5_400_000)).toBe('1h 30m');
+    expect(formatDuration(0)).toBe('0h 0m');
+    expect(formatDuration(7_200_000 + 900_000)).toBe('2h 15m');
+  });
+});

--- a/packages/agent/tests/pipeline.test.ts
+++ b/packages/agent/tests/pipeline.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../src/config.js', () => ({
+  env: {
+    OPENROUTER_API_KEY: 'test-key',
+    OPENROUTER_MODEL: 'test-model',
+    LOG_LEVEL: 'error',
+    isDevelopment: false,
+    COLLECTION_PERIOD_DAYS: 14,
+    ANOMALY_THRESHOLD: 2.0,
+    LLM_TOP_REPOS: 30,
+    LLM_TOP_PROGRAMS: 15,
+    LLM_TOP_TOKENS: 20,
+    COINGECKO_MAX_PAGES: 2,
+    DEFILLAMA_MIN_TVL: 100000,
+    CACHE_ENABLED: false,
+    REPORTS_DIR: '/tmp/solis-test-reports',
+    ENABLE_REPO_DISCOVERY: false,
+    ENABLE_SOCIAL_SIGNALS: false,
+    ENABLE_X_SIGNALS: false,
+  },
+}));
+
+vi.mock('../src/logger.js', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  },
+}));
+
+// Mock all collectors
+const mockCollectGitHub = vi.fn();
+const mockCollectDefiLlama = vi.fn();
+const mockCollectCoinGecko = vi.fn();
+const mockCollectHelius = vi.fn();
+
+vi.mock('../src/tools/github.js', () => ({
+  collectGitHub: (...args: unknown[]) => mockCollectGitHub(...args),
+}));
+vi.mock('../src/tools/defillama.js', () => ({
+  collectDefiLlama: (...args: unknown[]) => mockCollectDefiLlama(...args),
+}));
+vi.mock('../src/tools/coingecko.js', () => ({
+  collectCoinGecko: (...args: unknown[]) => mockCollectCoinGecko(...args),
+}));
+vi.mock('../src/tools/helius.js', () => ({
+  collectHelius: (...args: unknown[]) => mockCollectHelius(...args),
+}));
+
+vi.mock('../src/repos/curated.js', () => ({
+  getAllRepoNames: () => ['solana-labs/solana', 'coral-xyz/anchor'],
+}));
+
+vi.mock('../src/cache/star-history.js', () => ({
+  recordStars: vi.fn(),
+  loadStarHistory: vi.fn().mockResolvedValue({}),
+  enrichWithStarHistory: vi.fn(),
+}));
+
+vi.mock('../src/utils/reports.js', () => ({
+  loadPreviousReport: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('../src/utils/deltas.js', () => ({
+  applyDeltas: vi.fn(),
+}));
+
+const mockClusterNarratives = vi.fn();
+vi.mock('../src/analysis/clustering.js', () => ({
+  clusterNarratives: (...args: unknown[]) => mockClusterNarratives(...args),
+}));
+
+const mockGenerateBuildIdeas = vi.fn();
+vi.mock('../src/analysis/ideas.js', () => ({
+  generateBuildIdeas: (...args: unknown[]) => mockGenerateBuildIdeas(...args),
+}));
+
+const mockWriteJsonReport = vi.fn();
+const mockWriteMarkdownReport = vi.fn();
+const mockSendReportAlerts = vi.fn();
+
+vi.mock('../src/output/json.js', () => ({
+  writeJsonReport: (...args: unknown[]) => mockWriteJsonReport(...args),
+}));
+vi.mock('../src/output/markdown.js', () => ({
+  writeMarkdownReport: (...args: unknown[]) => mockWriteMarkdownReport(...args),
+}));
+vi.mock('../src/output/alerts.js', () => ({
+  sendReportAlerts: (...args: unknown[]) => mockSendReportAlerts(...args),
+  sendFailureAlert: vi.fn(),
+}));
+
+vi.mock('../src/utils/history.js', () => ({
+  computeReportDiff: vi.fn().mockReturnValue({
+    newNarratives: [],
+    removedNarratives: [],
+    stageTransitions: [],
+    confidenceChanges: [],
+  }),
+}));
+
+import { runPipeline } from '../src/index.js';
+
+const emptyGitHub = {
+  period: { start: '', end: '' },
+  repos: [],
+  anomalies: [],
+  newRepoClusters: [],
+};
+
+const emptyDefiLlama = {
+  period: { start: '', end: '' },
+  tvl: { total: 0, totalDelta: 0, protocols: [], anomalies: [] },
+  dexVolumes: { total: 0, protocols: [] },
+  stablecoinFlows: { netFlow: 0, inflows: 0, outflows: 0 },
+};
+
+const emptyConfirming = {
+  period: { start: '', end: '' },
+  tokens: [],
+  trending: [],
+  categoryPerformance: [],
+};
+
+function setupMocks() {
+  mockCollectGitHub.mockResolvedValue(emptyGitHub);
+  mockCollectDefiLlama.mockResolvedValue(emptyDefiLlama);
+  mockCollectHelius.mockResolvedValue([]);
+  mockCollectCoinGecko.mockResolvedValue(emptyConfirming);
+
+  mockClusterNarratives.mockResolvedValue({
+    narratives: [],
+    tokensUsed: 100,
+    costUsd: 0.001,
+  });
+
+  mockGenerateBuildIdeas.mockResolvedValue({
+    ideas: [],
+    tokensUsed: 50,
+    costUsd: 0.0005,
+  });
+
+  mockWriteJsonReport.mockResolvedValue(undefined);
+  mockWriteMarkdownReport.mockResolvedValue(undefined);
+  mockSendReportAlerts.mockResolvedValue(undefined);
+}
+
+describe('runPipeline', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupMocks();
+  });
+
+  it('completes pipeline and writes output', async () => {
+    await runPipeline();
+
+    expect(mockCollectGitHub).toHaveBeenCalled();
+    expect(mockCollectDefiLlama).toHaveBeenCalled();
+    expect(mockCollectHelius).toHaveBeenCalled();
+    expect(mockCollectCoinGecko).toHaveBeenCalled();
+    expect(mockClusterNarratives).toHaveBeenCalled();
+    expect(mockGenerateBuildIdeas).toHaveBeenCalled();
+    expect(mockWriteJsonReport).toHaveBeenCalled();
+    expect(mockWriteMarkdownReport).toHaveBeenCalled();
+  });
+
+  it('sends alerts after output phase', async () => {
+    await runPipeline();
+    expect(mockSendReportAlerts).toHaveBeenCalled();
+  });
+
+  it('completes when a collector fails (graceful degradation)', async () => {
+    mockCollectGitHub.mockRejectedValue(new Error('GitHub API down'));
+
+    await runPipeline();
+
+    // Pipeline still completes with empty fallback for GitHub
+    expect(mockClusterNarratives).toHaveBeenCalled();
+    expect(mockWriteJsonReport).toHaveBeenCalled();
+  });
+
+  it('completes when multiple collectors fail', async () => {
+    mockCollectGitHub.mockRejectedValue(new Error('GitHub down'));
+    mockCollectDefiLlama.mockRejectedValue(new Error('DeFi Llama down'));
+    mockCollectHelius.mockRejectedValue(new Error('Helius down'));
+
+    await runPipeline();
+
+    expect(mockClusterNarratives).toHaveBeenCalled();
+    expect(mockWriteJsonReport).toHaveBeenCalled();
+  });
+
+  it('throws when LLM clustering fails fatally', async () => {
+    mockClusterNarratives.mockRejectedValue(new Error('LLM catastrophic failure'));
+
+    await expect(runPipeline()).rejects.toThrow('LLM catastrophic failure');
+  });
+});

--- a/packages/web/next.config.ts
+++ b/packages/web/next.config.ts
@@ -1,10 +1,33 @@
 import type { NextConfig } from 'next';
 import { resolve } from 'node:path';
 
+const securityHeaders = [
+  { key: 'X-Frame-Options', value: 'DENY' },
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+  { key: 'Strict-Transport-Security', value: 'max-age=63072000; includeSubDomains; preload' },
+  { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
+  {
+    key: 'Content-Security-Policy',
+    value: [
+      "default-src 'self'",
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+      "style-src 'self' 'unsafe-inline'",
+      "img-src 'self' data: https:",
+      "font-src 'self' data:",
+      "connect-src 'self' https://openrouter.ai https://x402.org",
+      "frame-ancestors 'none'",
+    ].join('; '),
+  },
+];
+
 const nextConfig: NextConfig = {
   output: 'standalone',
   outputFileTracingRoot: resolve(import.meta.dirname, '..', '..'),
   transpilePackages: ['@solis/shared'],
+  async headers() {
+    return [{ source: '/(.*)', headers: securityHeaders }];
+  },
 };
 
 export default nextConfig;

--- a/packages/web/next.config.ts
+++ b/packages/web/next.config.ts
@@ -11,7 +11,7 @@ const securityHeaders = [
     key: 'Content-Security-Policy',
     value: [
       "default-src 'self'",
-      "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+      "script-src 'self' 'unsafe-inline'", // unsafe-inline required by Next.js runtime scripts
       "style-src 'self' 'unsafe-inline'",
       "img-src 'self' data: https:",
       "font-src 'self' data:",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@solis/shared": "workspace:*",
+    "envalid": "^8.0.0",
     "next": "^15.3.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/packages/web/src/app/api/digest/route.ts
+++ b/packages/web/src/app/api/digest/route.ts
@@ -37,9 +37,9 @@ export async function POST(request: Request) {
     const result = await sendDigest(body.date);
     return NextResponse.json(result);
   } catch (err) {
-    return NextResponse.json(
-      { error: `Digest failed: ${(err as Error).message}` },
-      { status: 500 },
-    );
+    const message = process.env.NODE_ENV === 'production'
+      ? 'Digest failed'
+      : `Digest failed: ${(err as Error).message}`;
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/packages/web/src/app/api/digest/route.ts
+++ b/packages/web/src/app/api/digest/route.ts
@@ -2,9 +2,10 @@ import { NextResponse } from 'next/server';
 import { timingSafeEqual } from 'node:crypto';
 import { sendDigest } from '@/lib/digest';
 import { checkBodySize } from '@/lib/api-guard';
+import { webEnv } from '@/lib/env';
 
 function isAuthorized(secret: string | null): boolean {
-  const expected = process.env.DIGEST_API_SECRET;
+  const expected = webEnv.DIGEST_API_SECRET;
   if (!expected || !secret) return false;
   const a = Buffer.from(expected);
   const b = Buffer.from(secret);

--- a/packages/web/src/app/api/digest/route.ts
+++ b/packages/web/src/app/api/digest/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { timingSafeEqual } from 'node:crypto';
 import { sendDigest } from '@/lib/digest';
+import { checkBodySize } from '@/lib/api-guard';
 
 function isAuthorized(secret: string | null): boolean {
   const expected = process.env.DIGEST_API_SECRET;
@@ -12,6 +13,9 @@ function isAuthorized(secret: string | null): boolean {
 }
 
 export async function POST(request: Request) {
+  const bodyCheck = await checkBodySize(request, 1024);
+  if (bodyCheck) return bodyCheck;
+
   const secret = request.headers.get('x-digest-secret');
   if (!isAuthorized(secret)) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/packages/web/src/app/api/digest/route.ts
+++ b/packages/web/src/app/api/digest/route.ts
@@ -1,9 +1,19 @@
 import { NextResponse } from 'next/server';
+import { timingSafeEqual } from 'node:crypto';
 import { sendDigest } from '@/lib/digest';
+
+function isAuthorized(secret: string | null): boolean {
+  const expected = process.env.DIGEST_API_SECRET;
+  if (!expected || !secret) return false;
+  const a = Buffer.from(expected);
+  const b = Buffer.from(secret);
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
 
 export async function POST(request: Request) {
   const secret = request.headers.get('x-digest-secret');
-  if (!process.env.DIGEST_API_SECRET || secret !== process.env.DIGEST_API_SECRET) {
+  if (!isAuthorized(secret)) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 

--- a/packages/web/src/app/api/query/route.ts
+++ b/packages/web/src/app/api/query/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { apiGuard, getGuardHeaders, checkBodySize } from '@/lib/api-guard';
+import { apiGuard, getGuardHeaders, checkBodySize, handleCorsOptions } from '@/lib/api-guard';
 import { getLatestReport, getReport } from '@/lib/reports';
 import { queryLLM } from '@/lib/openrouter';
 import type { QueryRequest, QueryResponse } from '@solis/shared';
@@ -22,6 +22,10 @@ function buildContext(report: import('@solis/shared').FortnightlyReport): string
     .join('\n');
 
   return `Report Date: ${report.generatedAt}\nPeriod: ${report.period.start} to ${report.period.end}\n\nNarratives:\n${narrativeSummary}\n\nTop Repos:\n${topRepos}\n\nTop Tokens:\n${topTokens}\n\nMeta: ${report.meta.narrativesIdentified} narratives, ${report.meta.anomaliesDetected} anomalies, ${report.meta.totalReposAnalyzed} repos analyzed`;
+}
+
+export function OPTIONS(request: Request) {
+  return handleCorsOptions(request) ?? new Response(null, { status: 204 });
 }
 
 export async function POST(request: Request) {

--- a/packages/web/src/app/api/query/route.ts
+++ b/packages/web/src/app/api/query/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { apiGuard, getGuardHeaders } from '@/lib/api-guard';
+import { apiGuard, getGuardHeaders, checkBodySize } from '@/lib/api-guard';
 import { getLatestReport, getReport } from '@/lib/reports';
 import { queryLLM } from '@/lib/openrouter';
 import type { QueryRequest, QueryResponse } from '@solis/shared';
@@ -25,6 +25,9 @@ function buildContext(report: import('@solis/shared').FortnightlyReport): string
 }
 
 export async function POST(request: Request) {
+  const bodyCheck = await checkBodySize(request, 1024);
+  if (bodyCheck) return bodyCheck;
+
   const guard = await apiGuard(request, {
     limit: 5,
     resource: '/api/query',

--- a/packages/web/src/app/api/query/route.ts
+++ b/packages/web/src/app/api/query/route.ts
@@ -82,9 +82,9 @@ export async function POST(request: Request) {
     const headers = getGuardHeaders(request);
     return NextResponse.json(response, { headers });
   } catch (err) {
-    return NextResponse.json(
-      { error: `LLM query failed: ${(err as Error).message}` },
-      { status: 502 },
-    );
+    const message = process.env.NODE_ENV === 'production'
+      ? 'LLM query failed'
+      : `LLM query failed: ${(err as Error).message}`;
+    return NextResponse.json({ error: message }, { status: 502 });
   }
 }

--- a/packages/web/src/app/api/reports/route.ts
+++ b/packages/web/src/app/api/reports/route.ts
@@ -1,8 +1,12 @@
 import { NextResponse } from 'next/server';
 import { getReportSummaries, getReport } from '@/lib/reports';
-import { apiGuard, getGuardHeaders } from '@/lib/api-guard';
+import { apiGuard, getGuardHeaders, handleCorsOptions } from '@/lib/api-guard';
 
 export const revalidate = 3600;
+
+export function OPTIONS(request: Request) {
+  return handleCorsOptions(request) ?? new Response(null, { status: 204 });
+}
 
 export async function GET(request: Request) {
   const guard = await apiGuard(request, { limit: 30, resource: '/api/reports' });

--- a/packages/web/src/app/api/reports/route.ts
+++ b/packages/web/src/app/api/reports/route.ts
@@ -21,5 +21,18 @@ export async function GET(request: Request) {
   }
 
   const summaries = await getReportSummaries();
+
+  const page = searchParams.get('page');
+  if (page) {
+    const pageNum = Math.max(1, parseInt(page, 10) || 1);
+    const limit = Math.min(100, Math.max(1, parseInt(searchParams.get('limit') ?? '20', 10)));
+    const start = (pageNum - 1) * limit;
+    const data = summaries.slice(start, start + limit);
+    return NextResponse.json({
+      data,
+      pagination: { page: pageNum, limit, total: summaries.length, pages: Math.ceil(summaries.length / limit) },
+    }, { headers });
+  }
+
   return NextResponse.json(summaries, { headers });
 }

--- a/packages/web/src/app/api/search/route.ts
+++ b/packages/web/src/app/api/search/route.ts
@@ -1,8 +1,12 @@
 import { NextResponse } from 'next/server';
 import { getAllNarrativesFlat } from '@/lib/reports';
-import { apiGuard, getGuardHeaders } from '@/lib/api-guard';
+import { apiGuard, getGuardHeaders, handleCorsOptions } from '@/lib/api-guard';
 
 export const revalidate = 3600;
+
+export function OPTIONS(request: Request) {
+  return handleCorsOptions(request) ?? new Response(null, { status: 204 });
+}
 
 export async function GET(request: Request) {
   const guard = await apiGuard(request, { limit: 60, resource: '/api/search' });

--- a/packages/web/src/app/api/search/route.ts
+++ b/packages/web/src/app/api/search/route.ts
@@ -10,5 +10,19 @@ export async function GET(request: Request) {
 
   const headers = getGuardHeaders(request);
   const items = await getAllNarrativesFlat();
+
+  const { searchParams } = new URL(request.url);
+  const page = searchParams.get('page');
+  if (page) {
+    const pageNum = Math.max(1, parseInt(page, 10) || 1);
+    const limit = Math.min(100, Math.max(1, parseInt(searchParams.get('limit') ?? '20', 10)));
+    const start = (pageNum - 1) * limit;
+    const data = items.slice(start, start + limit);
+    return NextResponse.json({
+      data,
+      pagination: { page: pageNum, limit, total: items.length, pages: Math.ceil(items.length / limit) },
+    }, { headers });
+  }
+
   return NextResponse.json(items, { headers });
 }

--- a/packages/web/src/app/api/signals/route.ts
+++ b/packages/web/src/app/api/signals/route.ts
@@ -1,11 +1,15 @@
 import { NextResponse } from 'next/server';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import { apiGuard, getGuardHeaders } from '@/lib/api-guard';
+import { apiGuard, getGuardHeaders, handleCorsOptions } from '@/lib/api-guard';
 
 export const revalidate = 3600;
 
 const REPORTS_DIR = join(process.cwd(), '../../reports/signals');
+
+export function OPTIONS(request: Request) {
+  return handleCorsOptions(request) ?? new Response(null, { status: 204 });
+}
 
 export async function GET(request: Request) {
   const guard = await apiGuard(request, { limit: 30, resource: '/api/signals' });

--- a/packages/web/src/app/api/signals/route.ts
+++ b/packages/web/src/app/api/signals/route.ts
@@ -19,6 +19,10 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: 'date parameter required' }, { status: 400, headers });
   }
 
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    return NextResponse.json({ error: 'Invalid date format' }, { status: 400, headers });
+  }
+
   try {
     const content = await readFile(join(REPORTS_DIR, `${date}.json`), 'utf-8');
     return NextResponse.json(JSON.parse(content), { headers });

--- a/packages/web/src/app/api/subscribe/route.ts
+++ b/packages/web/src/app/api/subscribe/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { apiGuard, getGuardHeaders } from '@/lib/api-guard';
+import { apiGuard, getGuardHeaders, checkBodySize } from '@/lib/api-guard';
 import {
   addSubscriber,
   removeSubscriber,
@@ -8,6 +8,9 @@ import {
 } from '@/lib/subscribers';
 
 export async function POST(request: Request) {
+  const bodyCheck = await checkBodySize(request, 1024);
+  if (bodyCheck) return bodyCheck;
+
   const guard = await apiGuard(request, { limit: 10, resource: '/api/subscribe' });
   if (guard) return guard;
 

--- a/packages/web/src/app/api/subscribe/route.ts
+++ b/packages/web/src/app/api/subscribe/route.ts
@@ -1,11 +1,15 @@
 import { NextResponse } from 'next/server';
-import { apiGuard, getGuardHeaders, checkBodySize } from '@/lib/api-guard';
+import { apiGuard, getGuardHeaders, checkBodySize, handleCorsOptions } from '@/lib/api-guard';
 import {
   addSubscriber,
   removeSubscriber,
   isValidEmail,
   verifyUnsubscribeToken,
 } from '@/lib/subscribers';
+
+export function OPTIONS(request: Request) {
+  return handleCorsOptions(request) ?? new Response(null, { status: 204 });
+}
 
 export async function POST(request: Request) {
   const bodyCheck = await checkBodySize(request, 1024);

--- a/packages/web/src/app/report/[date]/page.tsx
+++ b/packages/web/src/app/report/[date]/page.tsx
@@ -9,6 +9,7 @@ import { NarrativeStageGroup } from '@/components/narrative-stage-group';
 import { BuildIdeasFilter } from '@/components/build-ideas-filter';
 import { DataSourcesCard } from '@/components/data-sources-card';
 import { ConfidenceChart } from '@/components/charts/confidence-chart';
+import { ChartErrorBoundary } from '@/components/chart-error-boundary';
 
 export const revalidate = 3600;
 
@@ -60,7 +61,9 @@ export default async function ReportPage({ params }: { params: Promise<{ date: s
 
       <section id="summary" className="space-y-4">
         <ReportMetrics meta={report.meta} />
-        <ConfidenceChart narratives={report.narratives} />
+        <ChartErrorBoundary fallbackLabel="Confidence chart unavailable">
+          <ConfidenceChart narratives={report.narratives} />
+        </ChartErrorBoundary>
       </section>
 
       {hasDiff && (

--- a/packages/web/src/app/trends/page.tsx
+++ b/packages/web/src/app/trends/page.tsx
@@ -1,5 +1,6 @@
 import { getAllReports } from '@/lib/reports';
 import { MetaTrendsChart } from '@/components/charts/meta-trends';
+import { ChartErrorBoundary } from '@/components/chart-error-boundary';
 
 export const revalidate = 3600;
 
@@ -29,7 +30,9 @@ export default async function TrendsPage() {
           No reports available yet
         </div>
       ) : (
-        <MetaTrendsChart data={data} />
+        <ChartErrorBoundary fallbackLabel="Trends chart unavailable">
+          <MetaTrendsChart data={data} />
+        </ChartErrorBoundary>
       )}
 
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">

--- a/packages/web/src/components/chart-error-boundary.tsx
+++ b/packages/web/src/components/chart-error-boundary.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { Component, type ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+  fallbackLabel?: string;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export class ChartErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex items-center justify-center rounded-xl border border-white/10 bg-white/5 p-8 backdrop-blur-md">
+          <p className="text-sm text-white/50">
+            {this.props.fallbackLabel ?? 'Chart unavailable'}
+          </p>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/packages/web/src/components/narrative-timeline.tsx
+++ b/packages/web/src/components/narrative-timeline.tsx
@@ -3,6 +3,7 @@
 import type { NarrativeTimeline } from '@/lib/timeline';
 import { StageBadge } from './stage-badge';
 import { TimelineChart } from './charts/timeline-chart';
+import { ChartErrorBoundary } from './chart-error-boundary';
 import type { SignalStage } from '@solis/shared';
 
 const stageOrder: Record<SignalStage, number> = {
@@ -54,7 +55,9 @@ export function NarrativeTimelineView({ timeline }: { timeline: NarrativeTimelin
       <section>
         <h2 className="text-lg font-semibold mb-4">Confidence Trend</h2>
         <div className="border border-sol-border rounded-lg bg-sol-card p-4">
-          <TimelineChart points={timeline.points} />
+          <ChartErrorBoundary fallbackLabel="Timeline chart unavailable">
+            <TimelineChart points={timeline.points} />
+          </ChartErrorBoundary>
         </div>
       </section>
 

--- a/packages/web/src/lib/api-guard.ts
+++ b/packages/web/src/lib/api-guard.ts
@@ -10,6 +10,31 @@ export interface GuardConfig {
 
 const DEFAULT_WINDOW_MS = 3_600_000; // 1 hour
 
+const ALLOWED_ORIGINS = new Set([
+  'https://solis.rectorspace.com',
+  'http://localhost:3001',
+]);
+
+function getCorsHeaders(request: Request): Record<string, string> {
+  const origin = request.headers.get('origin');
+  if (!origin || !ALLOWED_ORIGINS.has(origin)) return {};
+  return {
+    'Access-Control-Allow-Origin': origin,
+    'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type, x-payment, x-digest-secret',
+    'Access-Control-Max-Age': '86400',
+  };
+}
+
+export function handleCorsOptions(request: Request): Response | null {
+  if (request.method !== 'OPTIONS') return null;
+  const cors = getCorsHeaders(request);
+  if (!cors['Access-Control-Allow-Origin']) {
+    return new Response(null, { status: 204 });
+  }
+  return new Response(null, { status: 204, headers: cors });
+}
+
 /**
  * API guard — rate limiting + optional x402 micropayments.
  * Returns null to proceed, or a Response to reject (402/429/401).
@@ -60,7 +85,8 @@ export async function apiGuard(
   });
 }
 
-/** Extract stashed rate limit headers from the request (set by apiGuard). */
+/** Extract stashed rate limit headers + CORS from the request (set by apiGuard). */
 export function getGuardHeaders(request: Request): Record<string, string> {
-  return (request as Request & { _rateLimitHeaders?: Record<string, string> })._rateLimitHeaders || {};
+  const rateLimit = (request as Request & { _rateLimitHeaders?: Record<string, string> })._rateLimitHeaders || {};
+  return { ...rateLimit, ...getCorsHeaders(request) };
 }

--- a/packages/web/src/lib/api-guard.ts
+++ b/packages/web/src/lib/api-guard.ts
@@ -85,6 +85,22 @@ export async function apiGuard(
   });
 }
 
+const DEFAULT_MAX_BODY_BYTES = 102_400; // 100KB
+
+export async function checkBodySize(
+  request: Request,
+  maxBytes: number = DEFAULT_MAX_BODY_BYTES,
+): Promise<Response | null> {
+  const contentLength = request.headers.get('content-length');
+  if (contentLength && parseInt(contentLength, 10) > maxBytes) {
+    return new Response(
+      JSON.stringify({ error: `Request body too large (max ${maxBytes} bytes)` }),
+      { status: 413, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+  return null;
+}
+
 /** Extract stashed rate limit headers + CORS from the request (set by apiGuard). */
 export function getGuardHeaders(request: Request): Record<string, string> {
   const rateLimit = (request as Request & { _rateLimitHeaders?: Record<string, string> })._rateLimitHeaders || {};

--- a/packages/web/src/lib/digest.ts
+++ b/packages/web/src/lib/digest.ts
@@ -2,14 +2,15 @@ import { Resend } from 'resend';
 import { getReport } from './reports';
 import { loadSubscribers, generateUnsubscribeToken } from './subscribers';
 import { buildDigestHtml } from './digest-template';
+import { webEnv } from './env';
 
 const BASE_URL = 'https://solis.rectorspace.com';
 
 export async function sendDigest(reportDate: string): Promise<{ sent: number; errors: number }> {
-  const apiKey = process.env.RESEND_API_KEY;
+  const apiKey = webEnv.RESEND_API_KEY;
   if (!apiKey) throw new Error('RESEND_API_KEY not configured');
 
-  const fromEmail = process.env.DIGEST_FROM_EMAIL || 'digest@solis.rectorspace.com';
+  const fromEmail = webEnv.DIGEST_FROM_EMAIL;
 
   const report = await getReport(reportDate);
   if (!report) throw new Error(`Report not found for ${reportDate}`);

--- a/packages/web/src/lib/env.ts
+++ b/packages/web/src/lib/env.ts
@@ -1,0 +1,32 @@
+import { cleanEnv, str, num, bool } from 'envalid';
+
+export const webEnv = cleanEnv(process.env, {
+  NODE_ENV: str({
+    choices: ['development', 'production', 'test'] as const,
+    default: 'development',
+  }),
+
+  // OpenRouter — custom query API
+  OPENROUTER_API_KEY: str({ default: '' }),
+  QUERY_API_MODEL: str({ default: 'anthropic/claude-haiku-4-5-20251001' }),
+
+  // API rate limiting
+  API_RATE_LIMIT: num({ default: 30 }),
+  API_RATE_WINDOW_MS: num({ default: 3_600_000 }),
+
+  // x402 micropayments
+  ENABLE_X402: bool({ default: false }),
+  X402_RECEIVER_ADDRESS: str({ default: '' }),
+  X402_PRICE_CENTS: num({ default: 1 }),
+  X402_FACILITATOR_URL: str({ default: 'https://x402.org/facilitator' }),
+
+  // Email digest
+  RESEND_API_KEY: str({ default: '' }),
+  DIGEST_FROM_EMAIL: str({ default: 'digest@solis.rectorspace.com' }),
+  DIGEST_UNSUBSCRIBE_SECRET: str({ default: '' }),
+  DIGEST_API_SECRET: str({ default: '' }),
+
+  // Data
+  DATA_DIR: str({ default: '' }),
+  REPORTS_DIR: str({ default: '' }),
+});

--- a/packages/web/src/lib/openrouter.ts
+++ b/packages/web/src/lib/openrouter.ts
@@ -1,6 +1,5 @@
 import { fetchWithTimeout } from '@solis/shared/fetch';
-
-const DEFAULT_MODEL = 'anthropic/claude-haiku-4-5-20251001';
+import { webEnv } from './env';
 
 interface ChatMessage {
   role: 'system' | 'user' | 'assistant';
@@ -31,10 +30,10 @@ export async function queryLLM(
   userPrompt: string,
   model?: string,
 ): Promise<QueryResult> {
-  const apiKey = process.env.OPENROUTER_API_KEY;
+  const apiKey = webEnv.OPENROUTER_API_KEY;
   if (!apiKey) throw new Error('OPENROUTER_API_KEY not configured');
 
-  const selectedModel = model || process.env.QUERY_API_MODEL || DEFAULT_MODEL;
+  const selectedModel = model || webEnv.QUERY_API_MODEL;
 
   const messages: ChatMessage[] = [
     { role: 'system', content: systemPrompt },

--- a/packages/web/src/lib/openrouter.ts
+++ b/packages/web/src/lib/openrouter.ts
@@ -1,3 +1,5 @@
+import { fetchWithTimeout } from '@solis/shared/fetch';
+
 const DEFAULT_MODEL = 'anthropic/claude-haiku-4-5-20251001';
 
 interface ChatMessage {
@@ -39,7 +41,8 @@ export async function queryLLM(
     { role: 'user', content: userPrompt },
   ];
 
-  const res = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+  const res = await fetchWithTimeout('https://openrouter.ai/api/v1/chat/completions', {
+    timeoutMs: 60_000,
     method: 'POST',
     headers: {
       'Authorization': `Bearer ${apiKey}`,

--- a/packages/web/src/lib/reports.ts
+++ b/packages/web/src/lib/reports.ts
@@ -4,7 +4,14 @@ import type { FortnightlyReport, ReportSummary } from '@solis/shared';
 
 const REPORTS_DIR = process.env.REPORTS_DIR || join(process.cwd(), '../../reports');
 
+const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+export function isValidDateParam(date: string): boolean {
+  return DATE_REGEX.test(date);
+}
+
 export async function getReport(date: string): Promise<FortnightlyReport | null> {
+  if (!isValidDateParam(date)) return null;
   try {
     const content = await readFile(join(REPORTS_DIR, `${date}.json`), 'utf-8');
     return JSON.parse(content) as FortnightlyReport;

--- a/packages/web/src/lib/reports.ts
+++ b/packages/web/src/lib/reports.ts
@@ -41,40 +41,26 @@ export async function getReportDates(): Promise<string[]> {
 
 export async function getAllNarrativesFlat(): Promise<Array<{ date: string; narrative: import('@solis/shared').Narrative }>> {
   const dates = await getReportDates();
-  const result: Array<{ date: string; narrative: import('@solis/shared').Narrative }> = [];
+  const reports = await Promise.all(dates.map(async date => ({ date, report: await getReport(date) })));
 
-  for (const date of dates) {
-    const report = await getReport(date);
-    if (!report) continue;
-    for (const narrative of report.narratives) {
-      result.push({ date, narrative });
-    }
-  }
-
-  return result;
+  return reports.flatMap(({ date, report }) =>
+    report ? report.narratives.map(narrative => ({ date, narrative })) : [],
+  );
 }
 
 export async function getAllReports(): Promise<Array<{ date: string; report: FortnightlyReport }>> {
   const dates = await getReportDates();
-  const result: Array<{ date: string; report: FortnightlyReport }> = [];
-
-  for (const date of dates) {
-    const report = await getReport(date);
-    if (report) result.push({ date, report });
-  }
-
-  return result;
+  const results = await Promise.all(dates.map(async date => ({ date, report: await getReport(date) })));
+  return results.filter((r): r is { date: string; report: FortnightlyReport } => r.report !== null);
 }
 
 export async function getReportSummaries(): Promise<ReportSummary[]> {
   const dates = await getReportDates();
-  const summaries: ReportSummary[] = [];
+  const reports = await Promise.all(dates.map(async date => ({ date, report: await getReport(date) })));
 
-  for (const date of dates) {
-    const report = await getReport(date);
-    if (!report) continue;
-
-    summaries.push({
+  return reports
+    .filter((r): r is { date: string; report: FortnightlyReport } => r.report !== null)
+    .map(({ date, report }) => ({
       date,
       generatedAt: report.generatedAt,
       period: report.period,
@@ -85,8 +71,5 @@ export async function getReportSummaries(): Promise<ReportSummary[]> {
         momentum: n.momentum,
       })),
       buildIdeaCount: report.buildIdeas.length,
-    });
-  }
-
-  return summaries;
+    }));
 }

--- a/packages/web/src/lib/subscribers.ts
+++ b/packages/web/src/lib/subscribers.ts
@@ -1,13 +1,51 @@
-import { readFile, writeFile, rename, mkdir } from 'node:fs/promises';
+import { readFile, writeFile, rename, mkdir, open, unlink } from 'node:fs/promises';
 import { join, dirname } from 'node:path';
 import { createHmac, timingSafeEqual } from 'node:crypto';
 import type { Subscriber } from '@solis/shared';
 
 const DATA_DIR = process.env.DATA_DIR || process.cwd();
 const SUBS_FILE = 'subscribers.json';
+const LOCK_TIMEOUT_MS = 5_000;
+const LOCK_RETRY_MS = 50;
 
 function getSubsPath(): string {
   return join(DATA_DIR, SUBS_FILE);
+}
+
+function getLockPath(): string {
+  return `${getSubsPath()}.lock`;
+}
+
+async function withFileLock<T>(fn: () => Promise<T>): Promise<T> {
+  const lockPath = getLockPath();
+  const deadline = Date.now() + LOCK_TIMEOUT_MS;
+
+  while (Date.now() < deadline) {
+    try {
+      const fh = await open(lockPath, 'wx');
+      await fh.writeFile(String(process.pid));
+      await fh.close();
+      try {
+        return await fn();
+      } finally {
+        await unlink(lockPath).catch(() => {});
+      }
+    } catch (err: any) {
+      if (err.code !== 'EEXIST') throw err;
+      await new Promise(r => setTimeout(r, LOCK_RETRY_MS));
+    }
+  }
+
+  // Stale lock recovery — remove and retry once
+  await unlink(lockPath).catch(() => {});
+  const fh = await open(lockPath, 'wx');
+  await fh.writeFile(String(process.pid));
+  await fh.close();
+  try {
+    return await fn();
+  } finally {
+    await unlink(lockPath).catch(() => {});
+  }
 }
 
 export async function loadSubscribers(): Promise<Subscriber[]> {
@@ -28,24 +66,28 @@ async function saveSubscribers(subscribers: Subscriber[]): Promise<void> {
 }
 
 export async function addSubscriber(email: string): Promise<void> {
-  const subscribers = await loadSubscribers();
-  const existing = subscribers.find(s => s.email.toLowerCase() === email.toLowerCase());
-  if (existing) return; // already subscribed
+  await withFileLock(async () => {
+    const subscribers = await loadSubscribers();
+    const existing = subscribers.find(s => s.email.toLowerCase() === email.toLowerCase());
+    if (existing) return;
 
-  subscribers.push({
-    email: email.toLowerCase().trim(),
-    subscribedAt: new Date().toISOString(),
-    verified: true, // no email verification flow yet
+    subscribers.push({
+      email: email.toLowerCase().trim(),
+      subscribedAt: new Date().toISOString(),
+      verified: true, // no email verification flow yet
+    });
+
+    await saveSubscribers(subscribers);
   });
-
-  await saveSubscribers(subscribers);
 }
 
 export async function removeSubscriber(email: string): Promise<void> {
-  const subscribers = await loadSubscribers();
-  const filtered = subscribers.filter(s => s.email.toLowerCase() !== email.toLowerCase());
-  if (filtered.length === subscribers.length) return; // not found
-  await saveSubscribers(filtered);
+  await withFileLock(async () => {
+    const subscribers = await loadSubscribers();
+    const filtered = subscribers.filter(s => s.email.toLowerCase() !== email.toLowerCase());
+    if (filtered.length === subscribers.length) return;
+    await saveSubscribers(filtered);
+  });
 }
 
 function getHmacSecret(): string {

--- a/packages/web/src/lib/x402.ts
+++ b/packages/web/src/lib/x402.ts
@@ -1,3 +1,5 @@
+import { fetchWithTimeout } from '@solis/shared/fetch';
+
 // Solana USDC mint address
 const USDC_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
 
@@ -73,7 +75,7 @@ export async function verifyPayment(
   const facilitatorUrl = process.env.X402_FACILITATOR_URL || 'https://x402.org/facilitator';
 
   try {
-    const res = await fetch(`${facilitatorUrl}/verify`, {
+    const res = await fetchWithTimeout(`${facilitatorUrl}/verify`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(proof),

--- a/packages/web/tests/api/digest.test.ts
+++ b/packages/web/tests/api/digest.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+
+const ORIGINAL_ENV = { ...process.env };
+const TEST_SECRET = 'test-digest-secret-123';
+
+// Mock digest sender
+vi.mock('@/lib/digest', () => ({
+  sendDigest: vi.fn(),
+}));
+
+// Mock env module — webEnv reads at import time, so provide defaults
+vi.mock('@/lib/env', () => ({
+  webEnv: {
+    DIGEST_API_SECRET: TEST_SECRET,
+    NODE_ENV: 'test',
+  },
+}));
+
+import { sendDigest } from '@/lib/digest';
+
+function makeRequest(body?: string | object, headers?: Record<string, string>): Request {
+  const defaultHeaders: Record<string, string> = {
+    'Content-Type': 'application/json',
+    'x-forwarded-for': '10.0.0.1',
+  };
+  return new Request('http://localhost/api/digest', {
+    method: 'POST',
+    headers: { ...defaultHeaders, ...headers },
+    body: typeof body === 'string' ? body : body ? JSON.stringify(body) : undefined,
+  });
+}
+
+beforeEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  vi.mocked(sendDigest).mockResolvedValue({ sent: 5, errors: 0 });
+});
+
+afterEach(() => {
+  process.env = ORIGINAL_ENV;
+  vi.restoreAllMocks();
+});
+
+async function getHandler() {
+  const mod = await import('@/app/api/digest/route');
+  return mod.POST;
+}
+
+describe('/api/digest', () => {
+  it('returns 401 when no secret header provided', async () => {
+    const POST = await getHandler();
+    const res = await POST(makeRequest({ date: '2026-02-14' }));
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toContain('Unauthorized');
+  });
+
+  it('returns 401 for wrong secret', async () => {
+    const POST = await getHandler();
+    const res = await POST(makeRequest({ date: '2026-02-14' }, { 'x-digest-secret': 'wrong-secret' }));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 400 for invalid JSON body', async () => {
+    const POST = await getHandler();
+    const res = await POST(makeRequest('not-json{', { 'x-digest-secret': TEST_SECRET }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('Invalid JSON');
+  });
+
+  it('returns 400 for missing date', async () => {
+    const POST = await getHandler();
+    const res = await POST(makeRequest({}, { 'x-digest-secret': TEST_SECRET }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('Date');
+  });
+
+  it('returns 200 for valid request', async () => {
+    const POST = await getHandler();
+    const res = await POST(makeRequest({ date: '2026-02-14' }, { 'x-digest-secret': TEST_SECRET }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.sent).toBe(5);
+    expect(body.errors).toBe(0);
+    expect(sendDigest).toHaveBeenCalledWith('2026-02-14');
+  });
+
+  it('returns 500 when sendDigest throws', async () => {
+    vi.mocked(sendDigest).mockRejectedValue(new Error('Resend API down'));
+    const POST = await getHandler();
+    const res = await POST(makeRequest({ date: '2026-02-14' }, { 'x-digest-secret': TEST_SECRET }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toContain('Digest failed');
+  });
+});

--- a/packages/web/tests/api/reports.test.ts
+++ b/packages/web/tests/api/reports.test.ts
@@ -122,6 +122,28 @@ describe('/api/reports', () => {
     expect(body.error).toContain('not found');
   });
 
+  it('returns paginated results when ?page= present', async () => {
+    const GET = await getHandler();
+    const res = await GET(makeRequest('page=1&limit=1'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toHaveLength(1);
+    expect(body.pagination).toEqual({
+      page: 1,
+      limit: 1,
+      total: 1,
+      pages: 1,
+    });
+  });
+
+  it('returns raw array when ?page= absent (backward compat)', async () => {
+    const GET = await getHandler();
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(Array.isArray(body)).toBe(true);
+  });
+
   it('includes rate limit headers on success', async () => {
     const GET = await getHandler();
     const res = await GET(makeRequest());

--- a/packages/web/tests/api/reports.test.ts
+++ b/packages/web/tests/api/reports.test.ts
@@ -98,6 +98,21 @@ describe('/api/reports', () => {
     expect(getReport).toHaveBeenCalledWith('2026-02-14');
   });
 
+  it('rejects path traversal in date param via getReport validation', async () => {
+    // getReport returns null for invalid date formats (regex guard)
+    vi.mocked(getReport).mockResolvedValue(null);
+    const GET = await getHandler();
+    const traversals = [
+      'date=../../etc/passwd',
+      'date=2026-02-14/../../../etc/shadow',
+      'date=foo/bar',
+    ];
+    for (const q of traversals) {
+      const res = await GET(makeRequest(q));
+      expect(res.status).toBe(404);
+    }
+  });
+
   it('returns 404 for unknown date', async () => {
     vi.mocked(getReport).mockResolvedValue(null);
     const GET = await getHandler();

--- a/packages/web/tests/api/subscribe.test.ts
+++ b/packages/web/tests/api/subscribe.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { _resetStore } from '@/lib/rate-limit';
+
+const ORIGINAL_ENV = { ...process.env };
+
+// Mock subscribers
+vi.mock('@/lib/subscribers', () => ({
+  addSubscriber: vi.fn(),
+  removeSubscriber: vi.fn(),
+  isValidEmail: vi.fn((email: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)),
+  verifyUnsubscribeToken: vi.fn(),
+}));
+
+import { addSubscriber, removeSubscriber, verifyUnsubscribeToken, isValidEmail } from '@/lib/subscribers';
+
+function makePostRequest(body?: object): Request {
+  return new Request('http://localhost/api/subscribe', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-forwarded-for': '10.0.0.1',
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+function makeDeleteRequest(params?: Record<string, string>): Request {
+  const url = new URL('http://localhost/api/subscribe');
+  if (params) {
+    Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
+  }
+  return new Request(url.toString(), {
+    method: 'DELETE',
+    headers: { 'x-forwarded-for': '10.0.0.2' },
+  });
+}
+
+beforeEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  delete process.env.ENABLE_X402;
+  _resetStore();
+  vi.mocked(addSubscriber).mockResolvedValue(undefined);
+  vi.mocked(removeSubscriber).mockResolvedValue(undefined);
+  vi.mocked(verifyUnsubscribeToken).mockReturnValue(false);
+  vi.mocked(isValidEmail).mockImplementation((email: string) =>
+    /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) && email.length <= 320,
+  );
+});
+
+afterEach(() => {
+  process.env = ORIGINAL_ENV;
+  vi.restoreAllMocks();
+});
+
+async function getHandlers() {
+  const mod = await import('@/app/api/subscribe/route');
+  return { POST: mod.POST, DELETE: mod.DELETE };
+}
+
+describe('/api/subscribe POST', () => {
+  it('returns 400 for missing email', async () => {
+    const { POST } = await getHandlers();
+    const res = await POST(makePostRequest({}));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('required');
+  });
+
+  it('returns 400 for invalid email format', async () => {
+    vi.mocked(isValidEmail).mockReturnValue(false);
+    const { POST } = await getHandlers();
+    const res = await POST(makePostRequest({ email: 'not-an-email' }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('Invalid email');
+  });
+
+  it('returns 200 for valid subscribe', async () => {
+    const { POST } = await getHandlers();
+    const res = await POST(makePostRequest({ email: 'test@example.com' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(addSubscriber).toHaveBeenCalledWith('test@example.com');
+  });
+
+  it('returns 400 for invalid JSON', async () => {
+    const { POST } = await getHandlers();
+    const req = new Request('http://localhost/api/subscribe', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-forwarded-for': '10.0.0.1',
+      },
+      body: 'not json',
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 429 when rate limited', async () => {
+    const { POST } = await getHandlers();
+    // 10 requests allowed for subscribe
+    for (let i = 0; i < 10; i++) {
+      await POST(makePostRequest({ email: `user${i}@example.com` }));
+    }
+    const res = await POST(makePostRequest({ email: 'final@example.com' }));
+    expect(res.status).toBe(429);
+  });
+});
+
+describe('/api/subscribe DELETE', () => {
+  it('returns 400 for missing params', async () => {
+    const { DELETE } = await getHandlers();
+    const res = await DELETE(makeDeleteRequest());
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('required');
+  });
+
+  it('returns 400 for missing token', async () => {
+    const { DELETE } = await getHandlers();
+    const res = await DELETE(makeDeleteRequest({ email: 'test@example.com' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 401 for invalid token', async () => {
+    vi.mocked(verifyUnsubscribeToken).mockReturnValue(false);
+    const { DELETE } = await getHandlers();
+    const res = await DELETE(makeDeleteRequest({ email: 'test@example.com', token: 'bad' }));
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toContain('Invalid');
+  });
+
+  it('returns 200 for valid unsubscribe', async () => {
+    vi.mocked(verifyUnsubscribeToken).mockReturnValue(true);
+    const { DELETE } = await getHandlers();
+    const res = await DELETE(makeDeleteRequest({ email: 'test@example.com', token: 'valid' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(removeSubscriber).toHaveBeenCalledWith('test@example.com');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
 
   shared:
     devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.11
       typescript:
         specifier: ^5.8.3
         version: 5.9.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       '@solis/shared':
         specifier: workspace:*
         version: link:../../shared
+      envalid:
+        specifier: ^8.0.0
+        version: 8.1.1
       next:
         specifier: ^15.3.3
         version: 15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)

--- a/shared/package.json
+++ b/shared/package.json
@@ -6,12 +6,14 @@
   "main": "./src/types.ts",
   "types": "./src/types.ts",
   "exports": {
-    ".": "./src/types.ts"
+    ".": "./src/types.ts",
+    "./fetch": "./src/fetch.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
+    "@types/node": "^22.0.0",
     "typescript": "^5.8.3"
   }
 }

--- a/shared/src/fetch.ts
+++ b/shared/src/fetch.ts
@@ -1,0 +1,25 @@
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+export async function fetchWithTimeout(
+  input: string | URL | Request,
+  init?: RequestInit & { timeoutMs?: number },
+): Promise<Response> {
+  const timeoutMs = init?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const controller = new AbortController();
+  const { timeoutMs: _, signal: externalSignal, ...rest } = init ?? {};
+
+  // Link external signal if provided
+  if (externalSignal?.aborted) {
+    controller.abort(externalSignal.reason);
+  } else if (externalSignal) {
+    externalSignal.addEventListener('abort', () => controller.abort(externalSignal.reason), { once: true });
+  }
+
+  const timer = setTimeout(() => controller.abort(new Error(`Request timed out after ${timeoutMs}ms`)), timeoutMs);
+
+  try {
+    return await fetch(input, { ...rest, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}


### PR DESCRIPTION
## Summary

Addresses all findings from the code roast audit (scored 31/50). 22 commits across 4 phases:

**Phase 1 — Security Critical**
- Path traversal prevention via date regex validation on report/signals APIs
- Timing-safe comparison for digest API secret authentication

**Phase 2 — Reliability & Ops**
- File locking for concurrent subscriber operations (O_EXCL pattern)
- `fetchWithTimeout` (30s default) applied to all external API calls (agent tools + web)
- `.env.example` documenting all 30+ configuration variables
- LRU eviction cap (10K entries) on in-memory rate limiter
- Docker resource limits (1G memory, 1.5 CPU)
- CORS origin allowlist for API routes
- Security headers (CSP, HSTS, X-Frame-Options, etc.) via Next.js config

**Phase 3 — Performance & Polish**
- Parallelized sequential report loading with Promise.all
- API pagination (backward-compatible envelope pattern) for reports and search
- Request body size limits (1KB) on POST routes
- Rightmost non-private IP extraction from x-forwarded-for (anti-spoofing)
- Hardcoded VPS IP replaced with GitHub secret
- Configurable heartbeat lock file path
- React error boundaries for all chart components
- Centralized env validation with envalid for web package
- Sanitized error messages in production (generic) vs development (verbose)

**Phase 4 — Tests**
- `/api/subscribe` route tests (9 cases)
- `/api/digest` route tests (6 cases)
- Pipeline integration test (5 cases — graceful degradation, fatal LLM failure)
- Heartbeat lock/state utility tests (10 cases — extracted to heartbeat-utils.ts)

## Stats
- 43 files changed, +1311 / -199
- Test count: 353 → 392 (+39 new tests)
- All 392 tests pass, typecheck clean, production build verified

## Post-Merge Checklist
- [ ] Add `VPS_HOST` secret to GitHub repo (value from deploy.yml)
- [ ] SCP updated `docker-compose.yml` to VPS
- [ ] Verify security headers: `curl -I https://solis.rectorspace.com`
- [ ] Manual smoke test: path traversal dates on live API

## Test plan
- [x] `pnpm typecheck` — all packages clean
- [x] `pnpm test:run` — 392 tests pass (180 web + 212 agent)
- [x] `pnpm build` — production build succeeds
- [x] Path traversal test cases in reports + signals
- [x] Timing-safe comparison in digest auth
- [x] Rate limiter eviction test
- [x] IP spoofing test cases
- [x] Pagination backward-compatibility tests