### PR TITLE
fix(agent): OpenRouter transient error retry + heartbeat retry

### DIFF
--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -41,7 +41,12 @@ interface SourceResult {
   error?: string;
 }
 
-export async function runPipeline(): Promise<void> {
+export interface PipelineResult {
+  narratives: number;
+  anomalies: number;
+}
+
+export async function runPipeline(): Promise<PipelineResult> {
   const startTime = Date.now();
   const periodDays = env.COLLECTION_PERIOD_DAYS;
   const periodWeeks = Math.round(periodDays / 7);
@@ -315,6 +320,11 @@ export async function runPipeline(): Promise<void> {
       llmCostUsd: (clusterCost + ideaCost).toFixed(4),
       ...(failedSources.length > 0 ? { failedSources } : {}),
     }, 'SOLIS pipeline complete');
+
+    return {
+      narratives: narratives.length,
+      anomalies: scored.summary.totalAnomalies,
+    };
   } catch (error) {
     logger.error({ err: error instanceof Error ? { message: error.message, stack: error.stack, cause: error.cause } : error }, 'Pipeline failed');
     throw error;


### PR DESCRIPTION
## Summary

Mitigates the Feb 19 incident where a transient OpenRouter 401 ("User not found") caused an empty report to be committed (0 narratives despite 17 anomalies detected).

**Three-layered defense:**

- **Transient retry in OpenRouter** — 401/408/429 now retry the same model up to 2x with 3s/6s backoff before falling to the next model in the chain. Previously these threw immediately, bypassing the fallback chain entirely.

- **Pipeline result reporting** — `runPipeline()` returns `{ narratives, anomalies }` counts so the heartbeat daemon can detect empty reports (LLM failure was silently caught by clustering's error handler).

- **Heartbeat retry mechanism** — Two retry paths:
  1. Pipeline crash → retry after 30min instead of waiting 24h (max 2 retries/day)
  2. Empty report safety net → if anomalies > 0 but narratives = 0, skip commit and retry after 30min

## Test plan

- [x] 403 tests pass (180 web + 223 agent, +11 new)
- [x] TypeScript strict mode clean
- [ ] Deploy agent to VPS and verify next pipeline run produces report with narratives
- [ ] Verify retry behavior if OpenRouter returns transient error (can't easily simulate in prod)